### PR TITLE
refactor: replaced alert duration with classname property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "deep-feels-ui",
+  "name": "@alanpinhon/deep-feels-ui",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "deep-feels-ui",
+      "name": "@alanpinhon/deep-feels-ui",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,12 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
-  "keywords": ["design system", "UI components", "React", "styled-components"],
+  "keywords": [
+    "design system",
+    "UI components",
+    "React",
+    "styled-components"
+  ],
   "author": "Alan Pinhon",
   "license": "ISC",
   "publishConfig": {

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -9,7 +9,7 @@ import { Text } from './Text';
 import { setThemeColor } from '../theme/setThemeColor';
 
 export type AlertProps = {
-  duration: number;
+  className?: string;
   icon?: Extract<IconName, 'CheckIcon' | 'ErrorIcon'>;
   children: React.ReactNode;
   type: 'success' | 'error';
@@ -38,21 +38,11 @@ const StyledAlert = styled.div<AlertProps>`
   }
 `
 
-export const Alert = ({children, style, type, icon, duration = 5000}:AlertProps) => {
-  const theme = useTheme();
-
-  const [className, setClassName] = useState('active');
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setClassName('');
-    }, duration);
-
-    return () => clearTimeout(timer);
-  }, [duration]);  
+export const Alert = ({children, style, type, icon, className = 'active'}:AlertProps) => {
+  const theme = useTheme();  
 
   return (
-    <StyledAlert style={style} role='alert' theme={theme} type={type} duration={duration} className={className}>
+    <StyledAlert style={style} role='alert' theme={theme} type={type} className={className}>
       <Icon name={icon} size='lg' stroke={(icon === 'ErrorIcon') ? setErrorColor(theme) : setCheckColor(theme)}/>
       <Text variant='alert' color={setTextColor(theme)} style={{ marginLeft: '.5rem' }}>
         {children}

--- a/src/stories/Alert.stories.tsx
+++ b/src/stories/Alert.stories.tsx
@@ -14,7 +14,6 @@ export const Success: Story = {
     children: '¡Email enviado!',
     type: 'success',
     icon: 'CheckIcon',
-    duration: 2000
   }
 }
 
@@ -23,6 +22,5 @@ export const Error: Story = {
     children: 'Ocurrió un error',
     type: 'error',
     icon: 'ErrorIcon',
-    duration: 3000
   }
 }

--- a/tests/components/Alert.spec.tsx
+++ b/tests/components/Alert.spec.tsx
@@ -12,7 +12,6 @@ describe('tests in <Alert/>', () => {
 
     const { container } = render (
       <Alert
-        duration={2000}
         children={alertMsg}
         type='success'
         icon='CheckIcon'
@@ -38,7 +37,6 @@ describe('tests in <Alert/>', () => {
 
     const { container } = render (
       <Alert
-       duration={3000}
         children={alertMsg}
         type='error'
         icon='ErrorIcon'


### PR DESCRIPTION
Se cambió la propiedad `duration` por `className` para poder manejar en desarrollo el estado (clase) de la alerta. 🔄